### PR TITLE
Geolocation APIを利用して位置情報取得

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -22,17 +22,19 @@ export default {
     }
   },
   mounted() {
-    this.$axios('http://localhost:3000/api/gourmet/v1/', {
-      // パラメータの設定
-      params: {
-        key: process.env.apikey,
-        lat: '35.681236',
-        lng: '139.767125',
-        format: 'json',
-      },
-    })
-      .then(this.setShop)
-      .catch(this.setError)
+    navigator.geolocation.getCurrentPosition((position) => {
+      this.$axios('http://localhost:3000/api/gourmet/v1/', {
+        // パラメータの設定
+        params: {
+          key: process.env.apikey,
+          lat: position.coords.latitude, // 取得した緯度を設定
+          lng: position.coords.longitude, // 取得した経度を設定
+          format: 'json',
+        },
+      })
+        .then(this.setShop)
+        .catch(this.setError)
+    }, this.setError)
   },
   methods: {
     // レスポンスあとの処理


### PR DESCRIPTION
## 変更内容
- Geolocation API使用
- `navigator.geolocation.getCurrentPosition()`で現在位置を取得
- 現在位置をpositionオブジェクトで取得・表示

## 参考
https://b1tblog.com/2019/12/26/nuxt-app3/