### PR TITLE
店舗詳細ページのマークアップ・スタイリング

### DIFF
--- a/src/components/Atoms/Button/index.vue
+++ b/src/components/Atoms/Button/index.vue
@@ -29,6 +29,7 @@ export default {
   color: $text-color;
   @include font-bold;
   position: relative;
+  cursor: pointer;
   &::after {
     content: '';
     width: 100%;
@@ -43,6 +44,9 @@ export default {
     &::after {
       animation: flow-line 0.6s ease;
     }
+  }
+  &:focus {
+    outline: none;
   }
 }
 

--- a/src/components/Atoms/Td/index.vue
+++ b/src/components/Atoms/Td/index.vue
@@ -10,7 +10,7 @@
   @include font-normal;
   line-height: 1.6;
   @include media(md, max) {
-    padding: 8px;
+    padding: 12px 8px;
     @include fts(8.75);
   }
 }

--- a/src/components/Atoms/Th/index.vue
+++ b/src/components/Atoms/Th/index.vue
@@ -11,7 +11,7 @@
   @include font-bold;
   @include media(md, max) {
     max-width: 80px;
-    padding: 8px;
+    padding: 12px 8px;
     @include fts(8.75);
   }
 }

--- a/src/components/Modules/Coupon/index.stories.js
+++ b/src/components/Modules/Coupon/index.stories.js
@@ -16,6 +16,5 @@ const Template = (args, { argTypes }) => ({
 
 export const Default = Template.bind({})
 Default.args = {
-  href: '/',
   url: 'http://hogehogehogehoge.hoge',
 }

--- a/src/components/Modules/Coupon/index.vue
+++ b/src/components/Modules/Coupon/index.vue
@@ -2,7 +2,7 @@
   <div class="coupon">
     <div class="coupon__title">クーポン</div>
     <div class="coupon__body">
-      <a :href="href" class="coupon__link" @click="onClick">{{ url }}</a>
+      <a class="coupon__link" @click="onClick">{{ url }}</a>
     </div>
   </div>
 </template>
@@ -10,10 +10,6 @@
 <script>
 export default {
   props: {
-    href: {
-      type: String,
-      required: true,
-    },
     url: {
       type: String,
       required: true,
@@ -46,6 +42,7 @@ export default {
     border-radius: 4px 0 0 4px;
     @include media(md, max) {
       width: 100%;
+      padding: 8px 16px;
       border-radius: 4px 4px 0 0;
     }
   }
@@ -53,6 +50,7 @@ export default {
     width: calc(100% - var(--title-width));
     border: 1px solid $border-color;
     border-radius: 0 4px 4px 0;
+    background: $white-color;
     @include media(md, max) {
       width: 100%;
       border-radius: 0 0 4px 4px;
@@ -66,6 +64,8 @@ export default {
     line-height: 1.6;
     color: $text-color;
     transition: all 0.3s ease;
+    word-wrap: break-word;
+    cursor: pointer;
     &:hover {
       background: lighten($primary-color, 53%);
     }

--- a/src/components/Modules/Header/index.vue
+++ b/src/components/Modules/Header/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="header">
+  <header class="header">
     <Logo color="white" />
-  </div>
+  </header>
 </template>
 
 <script>

--- a/src/components/Modules/TableBlock/index.vue
+++ b/src/components/Modules/TableBlock/index.vue
@@ -20,7 +20,7 @@ export default {
       required: true,
     },
     text: {
-      type: String,
+      type: [String, Number],
       required: true,
     },
   },

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -30,4 +30,11 @@ html {
   box-sizing: border-box;
   margin: 0;
 }
+
+.container {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,18 +1,25 @@
 <template>
   <div>
+    <Header color="default" />
     <Nuxt />
   </div>
 </template>
+
+<script>
+import Header from '~/components/Modules/Header'
+
+export default {
+  components: {
+    Header,
+  },
+}
+</script>
 
 <style lang="scss">
 html {
   @include font-normal;
   font-size: 16px;
   word-spacing: 1px;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
   background: #f8f4f4;
 }
@@ -22,34 +29,5 @@ html {
 *::after {
   box-sizing: border-box;
   margin: 0;
-}
-
-.button--green {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #3b8070;
-  color: #3b8070;
-  text-decoration: none;
-  padding: 10px 30px;
-}
-
-.button--green:hover {
-  color: #fff;
-  background-color: #3b8070;
-}
-
-.button--grey {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #35495e;
-  color: #35495e;
-  text-decoration: none;
-  padding: 10px 30px;
-  margin-left: 15px;
-}
-
-.button--grey:hover {
-  color: #fff;
-  background-color: #35495e;
 }
 </style>

--- a/src/pages/_id.vue
+++ b/src/pages/_id.vue
@@ -1,35 +1,51 @@
 <template>
-  <div>
-    <ul>
-      <li>PC用クーポン：{{ shop.coupon_urls.pc }}</li>
-      <li>SP用クーポン：{{ shop.coupon_urls.sp }}</li>
-      <li>店名：{{ shop.name }}</li>
-      <li><img :src="shop.photo.pc.l" /></li>
-      <li>営業時間：{{ shop.open }}</li>
-      <li>定休日：{{ shop.close }}</li>
-      <li>アクセス：{{ shop.access }}</li>
-      <li>住所：{{ shop.address }}</li>
-      <li>最寄り駅：{{ shop.station_name }}</li>
-      <li>説明：{{ shop.catch }}</li>
-      <li>ジャンル：{{ shop.genre.name }}</li>
-      <li>ジャンル、キャッチ：{{ shop.genre.catch }}</li>
-      <li>飲み放題：{{ shop.free_drink }}</li>
-      <li>食べ放題：{{ shop.free_food }}</li>
-      <li>
-        平均ディナー予算：{{ shop.budget.average }}<br />{{ shop.budget_memo }}
-      </li>
-      <li>席数：{{ shop.capacity }}</li>
-      <li>個室：{{ shop.private_room }}</li>
-      <li>座敷：{{ shop.tatami }}</li>
-      <li>備考：{{ shop.shop_detail_memo }}</li>
-      <!-- <li>{{ shop }}</li> -->
-    </ul>
-    <button @click="back()">一覧に戻る</button>
+  <div class="container">
+    <div class="shop-header">
+      <div class="shop-header__thumb">
+        <img :src="shop.photo.pc.l" alt="店舗イメージ" />
+      </div>
+      <div class="shop-header__info">
+        <div class="shop-header__title">{{ shop.name }}</div>
+        <div class="shop-header__catch">{{ shop.genre.catch }}</div>
+        <Category :label="shop.genre.name" />
+      </div>
+    </div>
+    <div class="coupon-area">
+      <Coupon class="coupon--pc" :url="shop.coupon_urls.pc" />
+      <Coupon class="coupon--sp" :url="shop.coupon_urls.sp" />
+    </div>
+    <div class="table-area">
+      <TableBlock title="住所" :text="shop.address" />
+      <TableBlock title="アクセス" :text="shop.access" />
+      <TableBlock title="営業時間" :text="shop.open" />
+      <TableBlock title="定休日" :text="shop.close" />
+      <TableBlock title="平均予算" :text="shop.budget.average" />
+      <TableBlock title="飲み放題" :text="shop.free_drink" />
+      <TableBlock title="食べ放題" :text="shop.free_food" />
+      <TableBlock title="座席" :text="shop.capacity" />
+      <TableBlock title="個室" :text="shop.private_room" />
+      <TableBlock title="座敷" :text="shop.tatami" />
+      <TableBlock title="備考" :text="shop.shop_detail_memo" />
+    </div>
+    <div class="button-area">
+      <Button label="一覧に戻る" @onClick="back()" />
+    </div>
   </div>
 </template>
 
 <script>
+import Button from '~/components/Atoms/Button'
+import Category from '~/components/Atoms/Category'
+import Coupon from '~/components/Modules/Coupon'
+import TableBlock from '~/components/Modules/TableBlock'
+
 export default {
+  components: {
+    Button,
+    Category,
+    Coupon,
+    TableBlock,
+  },
   async asyncData({ $axios, params, env, redirect }) {
     const { data } = await $axios
       .get('http://localhost:3000/api/gourmet/v1/', {
@@ -53,3 +69,80 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" scoped>
+.container {
+  margin: 60px auto;
+  @include media(md, max) {
+    margin: 30px auto;
+  }
+}
+.shop-header {
+  display: flex;
+  --thumb-pc-size: 238px;
+  --thumb-sp-size: 120px;
+  &__thumb {
+    width: var(--thumb-pc-size);
+    @include media(md, max) {
+      width: var(--thumb-sp-size);
+    }
+    img {
+      width: 100%;
+    }
+  }
+  &__info {
+    width: calc(100% - var(--thumb-pc-size) - 40px);
+    margin: 0 0 0 40px;
+    @include media(md, max) {
+      width: calc(100% - var(--thumb-sp-size) - 20px);
+      margin: 0 0 0 20px;
+    }
+  }
+  &__title {
+    @include fts(25);
+    @include font-bold;
+    @include media(md, max) {
+      @include fts(12.5);
+    }
+  }
+  &__catch {
+    margin: 20px 0 0;
+    @include font-bold;
+    @include media(md, max) {
+      @include fts(8.75);
+    }
+  }
+  .category {
+    margin: 20px 0 0;
+  }
+}
+.coupon-area {
+  margin: 40px 0 60px;
+  @include media(md, max) {
+    margin: 20px 0 30px;
+  }
+}
+.coupon {
+  &--pc {
+    display: flex;
+    @include media(md, max) {
+      display: none;
+      border: 1px solid #000;
+    }
+  }
+  &--sp {
+    display: none;
+    @include media(md, max) {
+      display: flex;
+    }
+  }
+}
+.button-area {
+  display: flex;
+  justify-content: center;
+  margin: 60px auto 80px;
+  @include media(md, max) {
+    margin: 30px auto 40px;
+  }
+}
+</style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,33 +1,27 @@
 <template>
-  <div>
-    <header>
-      <Header color="default" />
-    </header>
-    <div class="container">
-      <div class="result">
-        <p>検索結果（{{ shops.length }}件）</p>
-        <p v-if="error" class="result--error">データの取得に失敗しました。</p>
-      </div>
-      <div class="shop-list">
-        <ShopBlock
-          v-for="shop in shops"
-          :key="shop.id"
-          :src="shop.photo.pc.l"
-          :alt="shop.id"
-          :shopname="shop.name"
-          :category="shop.genre.name"
-          :address="shop.address"
-          :business-hour="shop.open"
-          :budget="shop.budget.average"
-          @onClick="accessDetail(shop)"
-        />
-      </div>
+  <div class="container">
+    <div class="result">
+      <p>検索結果（{{ shops.length }}件）</p>
+      <p v-if="error" class="result--error">データの取得に失敗しました。</p>
+    </div>
+    <div class="shop-list">
+      <ShopBlock
+        v-for="shop in shops"
+        :key="shop.id"
+        :src="shop.photo.pc.l"
+        :alt="shop.id"
+        :shopname="shop.name"
+        :category="shop.genre.name"
+        :address="shop.address"
+        :business-hour="shop.open"
+        :budget="shop.budget.average"
+        @onClick="accessDetail(shop)"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import Header from '~/components/Modules/Header'
 import ShopBlock from '~/components/Modules/ShopBlock'
 
 const getCurrentPosition = () => {
@@ -37,7 +31,6 @@ const getCurrentPosition = () => {
 }
 export default {
   components: {
-    Header,
     ShopBlock,
   },
   data() {
@@ -92,6 +85,9 @@ export default {
 }
 .result {
   margin: 40px auto;
+  @include media(md, max) {
+    margin: 20px auto;
+  }
   &--error {
     text-align: center;
     @include font-bold;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -77,12 +77,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.container {
-  width: 100%;
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 20px;
-}
 .result {
   margin: 40px auto;
   @include media(md, max) {


### PR DESCRIPTION
# 概要
- 店舗詳細ページのマークアップ・スタイリング
- 各コンポーネントのスタイル調整
- クーポンのprops、`href` を削除
- クラスcontainerを全てのページに使えるようにした