### PR TITLE
loading表示タイミング変更

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -54,7 +54,7 @@ export default {
     return {
       shops: [],
       error: false,
-      loading: true,
+      loading: false,
       shopsFlag: false,
     }
   },


### PR DESCRIPTION
## 概要
ページ読み込み時にローディングは一旦非表示にして
初回アクセスだった場合にローディングを表示する

ページ遷移のときにローディングのレイアウトがおかしくなるので応急処置...