### PR TITLE
スケルトンスクリーン追加

### DIFF
--- a/src/components/Modules/Loading/index.vue
+++ b/src/components/Modules/Loading/index.vue
@@ -25,6 +25,7 @@ export default {
   position: fixed;
   top: 0;
   left: 0;
+  z-index: 9999;
 }
 .loading__inner {
   @include flex(wrap, flex-start, center);

--- a/src/components/Modules/ShopBlock/index.vue
+++ b/src/components/Modules/ShopBlock/index.vue
@@ -67,7 +67,6 @@ export default {
   background: $white-color;
   box-shadow: 0 6px 12px -6px rgba(45, 45, 45, 0.1);
   transition: all 0.3s ease;
-  cursor: pointer;
   @include media(md, max) {
     padding: 16px;
   }
@@ -109,11 +108,6 @@ export default {
 }
 .shop-block__title {
   width: 100%;
-  @include fts(15);
-  color: $text-color;
-  @include media(md, max) {
-    @include fts(10);
-  }
 }
 .category {
   margin: 16px 0;
@@ -121,14 +115,7 @@ export default {
     margin: 12px 0;
   }
 }
-.shop-info {
-  color: $text-color;
-  @include media(md, max) {
-    @include fts(8.75);
-  }
-}
 .shop-info__item {
-  line-height: 1.6;
   &:not(:first-child) {
     margin: 16px 0 0;
   }

--- a/src/components/Modules/SkeltonBlock/index.stories.js
+++ b/src/components/Modules/SkeltonBlock/index.stories.js
@@ -1,0 +1,12 @@
+import SkeltonBlock from './index.vue'
+
+export default {
+  title: 'Modules/SkeltonBlock',
+  component: SkeltonBlock,
+}
+
+export const $default = (argTypes) => ({
+  props: Object.keys(argTypes),
+  components: { SkeltonBlock },
+  template: '<SkeltonBlock />',
+})

--- a/src/components/Modules/SkeltonBlock/index.vue
+++ b/src/components/Modules/SkeltonBlock/index.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="shop-block">
+    <div class="shop-block__image"></div>
+    <div class="shop-block__body">
+      <h2 class="shop-block__title"></h2>
+      <div class="category"></div>
+      <ul class="shop-info">
+        <li class="shop-info__item"></li>
+        <li class="shop-info__item"></li>
+        <li class="shop-info__item"></li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.shop-block {
+  --pc-size: 238px;
+  --sp-size: 100px;
+  display: flex;
+  align-items: flex-start;
+  padding: 32px;
+  background: $white-color;
+  box-shadow: 0 6px 12px -6px rgba(45, 45, 45, 0.1);
+  transition: all 0.3s ease;
+  cursor: pointer;
+  @include media(md, max) {
+    padding: 16px;
+  }
+}
+.shop-block__image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: var(--pc-size);
+  height: var(--pc-size);
+  background: $border-color;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 1;
+  @include media(md, max) {
+    width: var(--sp-size);
+    height: var(--sp-size);
+  }
+  &::before {
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(#fff, 0.5),
+      transparent
+    );
+    position: absolute;
+    top: 0;
+    left: 0;
+    animation: skeleton-animation 1.2s linear infinite;
+  }
+  img {
+    display: block;
+    transition: all 0.4s ease;
+  }
+}
+.shop-block__body {
+  width: calc(100% - var(--pc-size) - 40px);
+  margin: 0 0 0 40px;
+  @include media(md, max) {
+    width: calc(100% - var(--sp-size) - 16px);
+    margin: 0 0 0 16px;
+  }
+}
+.shop-block__title {
+  width: 400px;
+  height: 24px;
+  background: $border-color;
+  position: relative;
+  @include media(md, max) {
+    width: 100%;
+  }
+  &::before {
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(#fff, 0.5),
+      transparent
+    );
+    position: absolute;
+    top: 0;
+    left: 0;
+    animation: skeleton-animation 1.2s linear infinite;
+  }
+}
+.category {
+  width: 80px;
+  height: 20px;
+  margin: 16px 0;
+  background: $border-color;
+  position: relative;
+  &::before {
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(#fff, 0.5),
+      transparent
+    );
+    position: absolute;
+    top: 0;
+    left: 0;
+    animation: skeleton-animation 1.2s linear infinite;
+  }
+}
+.shop-info {
+  color: $text-color;
+  @include media(md, max) {
+    @include fts(8.75);
+  }
+}
+.shop-info__item {
+  width: 100%;
+  height: 16px;
+  background: $border-color;
+  position: relative;
+  @include media(md, max) {
+    height: 14px;
+  }
+  &:not(:first-child) {
+    margin: 16px 0 0;
+  }
+  &::before {
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(#fff, 0.5),
+      transparent
+    );
+    position: absolute;
+    top: 0;
+    left: 0;
+    animation: skeleton-animation 1.2s linear infinite;
+  }
+}
+@keyframes skeleton-animation {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/src/components/Organisms/SkeltonList/index.stories.js
+++ b/src/components/Organisms/SkeltonList/index.stories.js
@@ -1,0 +1,12 @@
+import SkeltonList from './index.vue'
+
+export default {
+  title: 'Organisms/SkeltonList',
+  component: SkeltonList,
+}
+
+export const $default = (argTypes) => ({
+  props: Object.keys(argTypes),
+  components: { SkeltonList },
+  template: '<SkeltonList />',
+})

--- a/src/components/Organisms/SkeltonList/index.vue
+++ b/src/components/Organisms/SkeltonList/index.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="skelton-list">
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+    <SkeltonBlock />
+  </div>
+</template>
+
+<script>
+import SkeltonBlock from '~/components/Modules/SkeltonBlock'
+export default {
+  components: {
+    SkeltonBlock,
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.skelton-list {
+  & > * {
+    &:not(:first-child) {
+      margin: 32px 0 0;
+      @include media(md, max) {
+        margin: 20px 0 0;
+      }
+    }
+  }
+}
+</style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -26,6 +26,7 @@
         @onClick="accessDetail(shop)"
       />
     </div>
+    <SkeltonList v-if="skelton" />
     <Loading v-if="loading">読み込み中です</Loading>
   </div>
 </template>
@@ -33,6 +34,7 @@
 <script>
 import ShopBlock from '~/components/Modules/ShopBlock'
 import Loading from '~/components/Modules/Loading'
+import SkeltonList from '~/components/Organisms/SkeltonList'
 
 const getCurrentPosition = () => {
   return new Promise((resolve, reject) => {
@@ -42,6 +44,7 @@ const getCurrentPosition = () => {
 export default {
   components: {
     ShopBlock,
+    SkeltonList,
     Loading,
   },
   asyncData({ env }) {
@@ -56,6 +59,7 @@ export default {
       error: false,
       loading: true,
       shopsFlag: false,
+      skelton: true,
     }
   },
   async mounted() {
@@ -87,16 +91,22 @@ export default {
 
       // 初回アクセス時の処理
       this.loading = true
+      this.skelton = true
+      setTimeout(() => {
+        this.skelton = false
+      }, 500)
       setTimeout(() => {
         this.loading = false
       }, 2000)
       return
     }
     this.loading = false
+    this.skelton = false
 
     // 店舗が見つからない場合の処理
     if (this.shops.length === 0) {
       this.shopsFlag = true
+      this.loading = false
     }
   },
   methods: {
@@ -144,7 +154,7 @@ export default {
   }
 }
 .loading {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
 }


### PR DESCRIPTION
## 概要
API呼び出してるときにページが空の状態なので、
データ読み込み前はスケルトンスクリーンを表示する

## 変更
- SkeltonBlockコンポーネント追加
- SkeltonListコンポーネント追加
- トップに上2つのコンポーネントが使えるよう記述
- v-ifでイベント発火をコントロールする

### 参考
[CSSでスケルトンスクリーンを表現する](https://tech.arc-one.jp/skeleton-screen/)