### PR TITLE
住所からGoogleMapに遷移できるようにした

### DIFF
--- a/src/components/Modules/TableLinkBlock/index.stories.js
+++ b/src/components/Modules/TableLinkBlock/index.stories.js
@@ -1,0 +1,13 @@
+import TableLinkBlock from './index.vue'
+
+export default {
+  title: 'Modules/TableLinkBlock',
+  component: TableLinkBlock,
+}
+
+export const $default = (argTypes) => ({
+  props: Object.keys(argTypes),
+  components: { TableLinkBlock },
+  template:
+    '<TableLinkBlock title="タイトル" text="テキストが入ります" href="https://google.com" linktext="googleへ飛ぶ" />',
+})

--- a/src/components/Modules/TableLinkBlock/index.vue
+++ b/src/components/Modules/TableLinkBlock/index.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="table-block">
+    <Th>{{ title }}</Th>
+    <Td
+      >{{ text
+      }}<a class="link" :href="href"
+        >{{ linktext
+        }}<svg viewBox="0 0 16 16">
+          <path
+            d="M11.772 8.398a.582.582 0 00.047-.796l-5.52-5.427c-.235-.233-.609-.233-.796 0l-.328.328a.538.538 0 000 .795l4.772 4.679-4.772 4.725a.538.538 0 000 .795l.328.328c.187.234.561.234.795 0l5.474-5.427z"
+          /></svg></a
+    ></Td>
+  </div>
+</template>
+
+<script>
+import Th from '~/components/Atoms/Th'
+import Td from '~/components/Atoms/Td'
+
+export default {
+  components: {
+    Th,
+    Td,
+  },
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    text: {
+      type: [String, Number],
+      required: true,
+    },
+    href: {
+      type: String,
+      required: true,
+    },
+    linktext: {
+      type: [String, Number],
+      required: true,
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.table-block {
+  width: 100%;
+  display: flex;
+  .th {
+    margin: 0 8px 0 0;
+    @include media(md, max) {
+      margin: 0;
+    }
+  }
+}
+.table-block:last-child {
+  .th {
+    border-bottom: 1px solid $primary-color;
+  }
+  .td {
+    border-bottom: 1px solid $border-color;
+  }
+}
+.link {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+  color: #1ea7fd;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+    @include media(md, max) {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}
+</style>

--- a/src/pages/_id.vue
+++ b/src/pages/_id.vue
@@ -23,7 +23,12 @@
       />
     </div>
     <div class="table-area">
-      <TableBlock title="住所" :text="shop.address" />
+      <TableLinkBlock
+        title="住所"
+        :text="shop.address"
+        :href="'	http://maps.google.co.jp/maps?q=' + shop.name"
+        linktext="googlemapで見る"
+      />
       <TableBlock title="アクセス" :text="shop.access" />
       <TableBlock title="営業時間" :text="shop.open" />
       <TableBlock title="定休日" :text="shop.close" />
@@ -46,6 +51,7 @@ import Button from '~/components/Atoms/Button'
 import Category from '~/components/Atoms/Category'
 import Coupon from '~/components/Modules/Coupon'
 import TableBlock from '~/components/Modules/TableBlock'
+import TableLinkBlock from '~/components/Modules/TableLinkBlock'
 
 export default {
   components: {
@@ -53,6 +59,7 @@ export default {
     Category,
     Coupon,
     TableBlock,
+    TableLinkBlock,
   },
   async asyncData({ $axios, params, env, redirect }) {
     const baseUrl = env.baseUrl


### PR DESCRIPTION
## 概要
詳細ページの住所にgooglemapへの遷移urlを追加

## 変更
- リンクを含んだTableBlockのコンポーネントを作成（他にもっといい方法ありそうだけど...）
- 詳細ページに新しく作成したコンポーネントを追加